### PR TITLE
Resolve critical bugs & optimize code

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ nlp.add_pipe(
     "concise_concepts",
     config={
         "data": data,
-        "ent_score": True, # Entity Scoring section
+        "ent_score": True,  # Entity Scoring section
         "verbose": True,
         "exclude_pos": ["VERB", "AUX"],
         "exclude_dep": ["DOBJ", "PCOMP"],
@@ -70,7 +70,7 @@ options = {
 
 ents = doc.ents
 for ent in ents:
-    new_label = f"{ent.label_} ({float(ent._.ent_score):.0%})"
+    new_label = f"{ent.label_} ({ent._.ent_score:.0%})"
     options["colors"][new_label] = options["colors"].get(ent.label_.lower(), None)
     options["ents"].append(new_label)
     ent.label_ = new_label
@@ -128,13 +128,13 @@ data = {
 text = """Sony was founded in Japan."""
 
 nlp = spacy.load("en_core_web_lg")
-nlp.add_pipe("concise_concepts", config={"data": data, "ent_score": True})
+nlp.add_pipe("concise_concepts", config={"data": data, "ent_score": True, "case_sensitive": True})
 doc = nlp(text)
 
 print([(ent.text, ent.label_, ent._.ent_score) for ent in doc.ents])
 # output
 #
-# [('Sony', 'ORG', 0.63740385), ('Japan', 'GPE', 0.5896993)]
+# [('Sony', 'ORG', 0.5207586), ('Japan', 'GPE', 0.7371268)]
 ```
 
 ## Custom Embedding Models
@@ -151,5 +151,3 @@ model_path = "glove-wiki-gigaword-300"
 
 nlp.add_pipe("concise_concepts", config={"data": data, "model_path": model_path})
 ````
-
-

--- a/concise_concepts/conceptualizer/Conceptualizer.py
+++ b/concise_concepts/conceptualizer/Conceptualizer.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-import itertools
 import json
 import logging
 import re
@@ -25,19 +24,8 @@ class Conceptualizer:
         model_path: str = None,
         word_delimiter: str = "_",
         ent_score: bool = False,
-        exclude_pos: list = [
-            "VERB",
-            "AUX",
-            "ADP",
-            "DET",
-            "CCONJ",
-            "PUNCT",
-            "ADV",
-            "ADJ",
-            "PART",
-            "PRON",
-        ],
-        exclude_dep: list = [],
+        exclude_pos: list = None,
+        exclude_dep: list = None,
         include_compound_words: bool = False,
         case_sensitive: bool = False,
         json_path: str = "./matching_patterns.json",
@@ -81,10 +69,23 @@ class Conceptualizer:
         self.topn = topn
         self.model_path = model_path
         self.match_rule = {}
-        if exclude_pos:
-            self.match_rule["POS"] = {"NOT_IN": exclude_pos}
-        if exclude_dep:
-            self.match_rule["DEP"] = {"NOT_IN": exclude_dep}
+        if exclude_pos is None:
+            exclude_pos = [
+                "VERB",
+                "AUX",
+                "ADP",
+                "DET",
+                "CCONJ",
+                "PUNCT",
+                "ADV",
+                "ADJ",
+                "PART",
+                "PRON",
+            ]
+        self.match_rule["POS"] = {"NOT_IN": exclude_pos}
+        if exclude_dep is None:
+            exclude_dep = []
+        self.match_rule["DEP"] = {"NOT_IN": exclude_dep}
         self.json_path = json_path
         self.check_validity_path()
         self.include_compound_words = include_compound_words
@@ -107,7 +108,6 @@ class Conceptualizer:
         self.set_gensim_model()
         self.verify_data(self.verbose)
         self.expand_concepts()
-        self.verify_data(verbose=False)
         # settle words around overlapping concepts
         for _ in range(5):
             self.expand_concepts()
@@ -137,17 +137,14 @@ class Conceptualizer:
         If the user doesn't specify a topn value for each class,
         then the topn value for each class is set to 100
         """
-        self.topn_dict = {}
         if not self.topn:
-            for key in self.data:
-                self.topn_dict[key] = 100
+            self.topn_dict = {key: 100 for key in self.data}
         else:
-            num_classes = len(list(self.data.keys()))
+            num_classes = len(self.data)
             assert (
                 len(self.topn) == num_classes
             ), f"Provide a topn integer for each of the {num_classes} classes."
-            for key, n in zip(self.data, self.topn):
-                self.topn_dict[key] = n
+            self.topn_dict = dict(zip(self.data, self.topn))
 
     def set_gensim_model(self):
         """
@@ -179,7 +176,7 @@ class Conceptualizer:
 
             assert len(
                 self.nlp.vocab.vectors
-            ), "Choose a model with internal embeddings i.e. md or lg."
+            ), "Choose a spaCy model with internal embeddings, e.g. md or lg."
 
             for key, vector in self.nlp.vocab.vectors.items():
                 wordList.append(self.nlp.vocab.strings[key])
@@ -194,38 +191,36 @@ class Conceptualizer:
         It takes a dictionary of lists of words, and returns a dictionary of lists of words,
         where each word in the list is present in the word2vec model
         """
-        verified_data = dict()
+        verified_data: dict[str, list[str]] = dict()
         for key, value in self.data.items():
             verified_values = []
-            if not self.check_presence_vocab(key):
-                if verbose:
-                    if key not in self.log_cache["key"]:
-                        logger.warning(f"key ´{key}´ not present in vector model")
-                        self.log_cache["key"].append(key)
+            present_key = self.check_presence_vocab(key)
+            if not present_key and verbose and key not in self.log_cache["key"]:
+                logger.warning(f"key ´{key}´ not present in vector model")
+                self.log_cache["key"].append(key)
             for word in value:
-                if self.check_presence_vocab(word):
-                    verified_values.append(self.check_presence_vocab(word))
-                else:
-                    if verbose:
-                        if word not in self.log_cache["word"]:
-                            logger.warning(
-                                f"word ´{word}´ from key ´{key}´ not present in vector"
-                                " model"
-                            )
-                            self.log_cache["word"].append(word)
+                present_word = self.check_presence_vocab(word)
+                if present_word:
+                    verified_values.append(present_word)
+                elif verbose and word not in self.log_cache["word"]:
+                    logger.warning(
+                        f"word ´{word}´ from key ´{key}´ not present in vector model"
+                    )
+                    self.log_cache["word"].append(word)
             verified_data[key] = verified_values
             if not len(verified_values):
                 msg = (
                     f"None of the entries for key {key} are present in the vector"
                     " model. "
                 )
-                if self.check_presence_vocab(key):
-                    logger.warning(msg + f"Using {key} as word to expand over instead.")
-                    verified_data[key] = self.check_presence_vocab(key)
+                if present_key:
+                    logger.warning(
+                        msg + f"Using {present_key} as word to expand over instead."
+                    )
+                    verified_data[key] = present_key
                 else:
                     raise Exception(msg)
         self.data = deepcopy(verified_data)
-        self.original_data = deepcopy(self.data)
 
     def expand_concepts(self):
         """
@@ -233,63 +228,41 @@ class Conceptualizer:
         dictionary, and add those words to the values in the data dictionary
         """
 
+        self.original_data = deepcopy(self.data)
+
         for key in self.data:
-            remaining_keys = [rem_key for rem_key in self.data.keys() if rem_key != key]
-            remaining_values = [self.data[rem_key] for rem_key in remaining_keys]
-            remaining_values = list(itertools.chain.from_iterable(remaining_values))
-            if self.check_presence_vocab(key):
-                key_list = [self.check_presence_vocab(key)]
+            present_key = self.check_presence_vocab(key)
+            if present_key:
+                key_list = [present_key]
             else:
                 key_list = []
             similar = self.kv.most_similar(
                 positive=self.data[key] + key_list,
                 topn=self.topn_dict[key],
             )
-            similar = [sim_pair[0] for sim_pair in similar]
-            self.data[key] += similar
-            self.data[key] = list(set([word.lower() for word in self.data[key]]))
+            for word, _ratio in similar:
+                present_word = self.check_presence_vocab(word)
+                self.data[key].append(present_word if present_word else word)
+            self.data[key] = list(set(self.data[key]))
 
     def resolve_overlapping_concepts(self):
         """
         It removes words from the data that are in other concepts, and then removes words that are not closest to the
         centroid of the concept
         """
-        centroids = {}
-        for key in self.data:
-            if not self.check_presence_vocab(key):
-                words = self.data[key]
-                while len(words) != 1:
-                    words.remove(self.kv.doesnt_match(words))
-                centroids[key] = words[0]
-            else:
-                centroids[key] = key
-
-        for key_x in self.data:
-            for key_y in self.data:
-                if key_x != key_y:
-                    self.data[key_x] = [
-                        word
-                        for word in self.data[key_x]
-                        if word not in self.original_data[key_y]
-                    ]
-
         for key in self.data:
             self.data[key] = [
                 word
                 for word in self.data[key]
-                if centroids[key]
-                == self.kv.most_similar_to_given(word, list(centroids.values()))
+                if key == self.kv.most_similar_to_given(word, list(self.data.keys()))
             ]
-
-        self.centroids = centroids
 
     def infer_original_data(self):
         """
         It takes the original data and adds the new data to it, then removes the new data from the original data.
         """
         for key in self.data:
-            self.data[key] += self.original_data[key]
-            self.data[key] = list(set(self.data[key]))
+            self.data[key] = list(set(self.data[key] + self.original_data[key]))
 
         for key_x in self.data:
             for key_y in self.data:
@@ -299,8 +272,6 @@ class Conceptualizer:
                         for word in self.data[key_x]
                         if word not in self.original_data[key_y]
                     ]
-
-        self.verify_data(verbose=False)
 
     def lemmatize_concepts(self):
         """
@@ -347,7 +318,9 @@ class Conceptualizer:
                     words = [
                         "".join(
                             [
-                                token.lemma_ if token.lemma_ else token.text
+                                token.lemma_ + token.whitespace_
+                                if token.lemma_
+                                else token.text
                                 for token in doc
                             ]
                         )
@@ -357,9 +330,10 @@ class Conceptualizer:
                     words = input_dict[key]
                 for word in words:
                     if word != key:
-                        specific_match_rule = dict()
-                        specific_match_rule.update(self.match_rule)
-                        word_parts = re.split(f"[{self.word_delimiter}]+", word)
+                        specific_match_rule = {**self.match_rule}
+                        word_parts = re.split(
+                            f"[{re.escape(self.word_delimiter)}]+", word
+                        )
                         if len(word_parts) > 1:
                             operators = [" ", "-"]
                         else:
@@ -367,7 +341,7 @@ class Conceptualizer:
 
                         for op in operators:
                             if self.case_sensitive:
-                                specific_match_rule[self.match_key] = "{op}".join(
+                                specific_match_rule[self.match_key] = f"{op}".join(
                                     word_parts
                                 )
                             else:
@@ -404,7 +378,6 @@ class Conceptualizer:
                                 )
 
         add_patterns(self.data)
-        add_patterns(self.original_data)
         if self.json_path:
             with open(self.json_path, "w") as f:
                 json.dump(patterns, f)
@@ -453,16 +426,16 @@ class Conceptualizer:
                 if self.check_presence_vocab(ent.text):
                     entity = [ent.text]
                 else:
-                    entity = [
-                        self.check_presence_vocab(part)
-                        for part in ent.text.split()
-                        if self.check_presence_vocab(part)
-                    ]
-                concept = [
-                    self.check_presence_vocab(word)
-                    for word in self.data_upper[ent.label_]
-                    if self.check_presence_vocab(word)
-                ]
+                    entity = []
+                    for part in ent.text.split():
+                        present_part = self.check_presence_vocab(part)
+                        if present_part:
+                            entity.append(present_part)
+                concept = []
+                for word in self.data_upper[ent.label_]:
+                    present_word = self.check_presence_vocab(word)
+                    if present_word:
+                        concept.append(present_word)
                 if entity and concept:
                     ent._.ent_score = self.kv.n_similarity(entity, concept)
                 else:
@@ -487,10 +460,17 @@ class Conceptualizer:
         doc.ents = ents
         return doc
 
-    def check_presence_vocab(self, word):
+    def _check_presence_vocab(self, word: str) -> str:
+        if word in self.kv:
+            return word
         for op in [" ", "-"]:
             check_word = word.replace(op, self.word_delimiter)
-            if not self.case_sensitive:
-                check_word = check_word.lower()
             if check_word in self.kv:
                 return check_word
+
+    def check_presence_vocab(self, word: str) -> str:
+        if not word.islower() and not self.case_sensitive:
+            present_word = self._check_presence_vocab(word.lower())
+            if present_word:
+                return present_word
+        return self._check_presence_vocab(word)

--- a/concise_concepts/conceptualizer/Conceptualizer.py
+++ b/concise_concepts/conceptualizer/Conceptualizer.py
@@ -240,10 +240,9 @@ class Conceptualizer:
                 positive=self.data[key] + key_list,
                 topn=self.topn_dict[key],
             )
-            for word, _ratio in similar:
-                present_word = self.check_presence_vocab(word)
-                self.data[key].append(present_word if present_word else word)
-            self.data[key] = list(set(self.data[key]))
+            self.data[key] = list(
+                {self.check_presence_vocab(word) for word, _ratio in similar}
+            )
 
     def resolve_overlapping_concepts(self):
         """


### PR DESCRIPTION
Hello!

## Pull request overview
* Resolve several breaking bugs.
* Perform a large optimization regarding string normalization and KeyedVector membership.
* Perform simple code optimization each localized to just a few lines.

## Details
This PR has grown a bit bigger than anticipated, with an essentially unreadable diff. Apologies for that. I'll put comments for the smaller stuff in the diff itself, and explain my larger changes here:

### Large optimization/change regarding string normalization
I want to start with the large optimization regarding string normalization. I noticed that your code contains many calls to `verify_data`, and other checks to verify that the current `self.data` is valid, i.e., all keys and values are in the `self.kv` KeyedVector. 
However, this should only need to be checked once for the input data. All of the other words are produced directly by the gensim model, so how could they possible not occur in that same model? I did some debugging, and found the last line of this snippet to be responsible:
https://github.com/Pandora-Intelligence/concise-concepts/blob/75a64fd3aea86fc9ffeeeac15e8d302781dfd47f/concise_concepts/conceptualizer/Conceptualizer.py#L248-L250
The `.lower()` can convert a word which occurs in the `self.kv` to become a word which does not. This means that it is indeed necessary to call `verify_data` so often. However, we can avoid this problem altogether by simply modifying this:
```python
            self.data[key] = list(
                {self.check_presence_vocab(word) for word, _ratio in similar}
            )
```

This brings me to my next large modification that actually changes the behaviour: `self.check_presence_vocab`.
The current implementation is this:
https://github.com/Pandora-Intelligence/concise-concepts/blob/75a64fd3aea86fc9ffeeeac15e8d302781dfd47f/concise_concepts/conceptualizer/Conceptualizer.py#L490-L496

Although it works well most of the time, there are some flaws with this implementation:
1. ```python
    (Pdb) self.check_presence_vocab("CH-47F")  
    (Pdb) "CH-47F" in self.kv
    True
    ```
    The word itself, without any replacements, is never tried against `self.kv`, so for inputs like "CH-47F", `check_presence_vocab` says that they are not present, when they are. 

2. ```python
    (Pdb) self.check_presence_vocab("Gambia")
    (Pdb) "Gambia" in self.kv
    True
    ```
    The word is always normalized down to lowercase if we are case insensitive, even if *only* the non-lowercase word exists. This is not ideal, as you would expect "Gambia" to work still, even in case insensitive situations. (Actually, you would even expect "gambia" to work and match "Gambia", but that's a much more difficult issue, as only "Gambia" exists in the `kv`.)

The new implementation that I propose is like so:
```python
    def _check_presence_vocab(self, word: str) -> str:
        if word in self.kv:
            return word
        for op in [" ", "-"]:
            check_word = word.replace(op, self.word_delimiter)
            if check_word in self.kv:
                return check_word

    def check_presence_vocab(self, word: str) -> str:
        if not word.islower() and not self.case_sensitive:
            present_word = self._check_presence_vocab(word.lower())
            if present_word:
                return present_word
        return self._check_presence_vocab(word)
```
The bottom outermost function will first determine whether the word is non-lowercase. If it is, and we are case insensitive, then we want to first try for the lowercase word (e.g. `cauliflower` when the input is `Cauliflower`). If that fails, then we try for the actual word itself. This solves issue 2.
The inner function is similar to the original function, but it leaves the normalization to the outer function. Furthermore, it also matches the word itself. This solves issue 1.

In short, if `check_presence_vocab` is now called with a non-lowercase word, then we first try the lowercase variant if we have case insensitivity. Combined with the change above (i.e., no more `.lower()` before removing duplicates), finding both `cauliflower` and `Cauliflower` to be similar to vegetables means that this function will return `cauliflower` for both of them, and one will be removed as a duplicate.
And unlike previously, this ensures that the output of `self.expand_concepts()` is always correct (i.e. all keys and values are in `self.kv`), meaning we don't need to call `self.verify_data` anymore, and we no longer need to always check whether a value is actually in `self.kv` or not.

### Critical bugs
A large issue that I ran into was that that the following line is not prefixed with `f` like it should be:
https://github.com/Pandora-Intelligence/concise-concepts/blob/75a64fd3aea86fc9ffeeeac15e8d302781dfd47f/concise_concepts/conceptualizer/Conceptualizer.py#L370-L372

Furthermore, a large issue originates in the following two lines:
https://github.com/Pandora-Intelligence/concise-concepts/blob/75a64fd3aea86fc9ffeeeac15e8d302781dfd47f/concise_concepts/conceptualizer/Conceptualizer.py#L406-L407
As you can see from this experimentation:
```python
(Pdb) all(set(self.original_data[key]) == set(self.data[key]) for key in self.data))
True
```
which I ran on your main branch, the `self.original_data` and `self.data` dictionaries are the exact same. This makes sense, as `verify_data` was called just prior, and that method contains this:
https://github.com/Pandora-Intelligence/concise-concepts/blob/75a64fd3aea86fc9ffeeeac15e8d302781dfd47f/concise_concepts/conceptualizer/Conceptualizer.py#L227-L228

In short, all of the pattern data is added *twice*. You can verify this by searching in the produced `matching_patterns.json`. You'll find that everything occurs twice. Prior to this PR, running the main demo from the `README.md` produces a `fruitful_patterns.json` with 1090 patterns. After this PR, it is down to 590.

### Additional optimizations
I have implemented many small optimizations that affect only a few lines, and I'll highlight them in this PR's comments, so you can understand my reasoning for each. These are primarily focused only on rewriting into smaller equivalent code, as well as some unimportant fixes.

There are also a few style issues that I encountered which I would recommend tackling, but I realise that not everyone is open to a PR for those. For completeness, the two issues that I encountered are:
* Not matching variable name conventions here:
  https://github.com/Pandora-Intelligence/concise-concepts/blob/75a64fd3aea86fc9ffeeeac15e8d302781dfd47f/concise_concepts/conceptualizer/Conceptualizer.py#L177-L178
* Not matching filename conventions (`Conceptualizer.py` really ought to be named `conceptualizer.py` instead)

### Note
These changes *do* affect the program's output. I believe that all of my changes should in theory only improve the model performance, but the test suite isn't significant enough to properly detect negative changes too.
For completeness, the output for the main `README.md` codeblock is now:
![image](https://user-images.githubusercontent.com/37621491/200025414-a7b7aad9-9b96-4340-ae8f-5e2dfeef07a9.png)

I had fun messing around with your work here, and it's a very interesting idea. I did not anticipate for spaCy's EntityRuler to be so fast: I kind of wrote it off before, under the assumption that it would be super slow.

Let me know if you have any questions or if you need anything from me at this point. Apologies for the one big diff.

- Tom Aarsen